### PR TITLE
Added a socket to listen to an external file being run

### DIFF
--- a/spotify_lyrics.py
+++ b/spotify_lyrics.py
@@ -1,0 +1,5 @@
+
+import socket
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect(("localhost", 55555))

--- a/src/appIndicator.py
+++ b/src/appIndicator.py
@@ -22,8 +22,42 @@ class AppIndicator():
         indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
         indicator.set_menu(self.build_menu())
 
+        self.alive = True
+        self.listener = threading.Thread(target=self.socket_listener)
+        self.listener.start()
+
         self.Config = utils.get_config()
         Gtk.main()
+
+    def socket_listener(self):
+        import socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) 
+        sock.bind(("localhost", 55555))
+        sock.listen(1)
+        # sock.setblocking(0)
+
+        try:
+            while self.alive:
+                print("a")
+                try:
+                    print("b")
+                    connection, src_address = sock.accept()
+                    print("c")
+
+                    if self.alive:
+                        self.spotify_lyrics(None) # Triggers a Fatal IO error
+                except Exception as e:    
+                    connection.close()
+                    print(e)
+                finally:
+                    try:
+                        connection.close()
+                    except:
+                        pass
+        except:
+            pass
+        sock.close()
 
     def build_menu(self):
         menu = Gtk.Menu()
@@ -31,8 +65,11 @@ class AppIndicator():
         get_lyrics = Gtk.MenuItem('Get Lyrics')
         get_lyrics.connect('activate', self.fetch_lyrics)
 
+        global spotify_lyrics
+
         spotify_lyrics = Gtk.MenuItem('Spotify Lyrics')
         spotify_lyrics.connect('activate', self.spotify_lyrics)
+        print(spotify_lyrics)
 
         preferences = Gtk.MenuItem('Preferences')
         preferences.connect('activate', self.preferences)
@@ -51,6 +88,7 @@ class AppIndicator():
         win = LyricsWindow("get", self)
 
     def spotify_lyrics(self, source):
+        print(source)
         win = LyricsWindow("spotify", self)
         thread = threading.Thread(target=win.get_spotify)
         thread.daemon = True
@@ -60,4 +98,10 @@ class AppIndicator():
         win = PreferenceWindow(self)
 
     def quit(self, source):
+        self.alive = False
+
+        import socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(("localhost", 55555))  # closes sock.accept()
+
         Gtk.main_quit()


### PR DESCRIPTION
Doesn't properly invoke the SpotifyLyrics window, probably due to threading and GTK not working well together. invoking an activate call directly would be better, but I'm not sure how to do that.

Work in progress for issue #17 .
Adding a new branch for this would be best.